### PR TITLE
Fast dev mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "types": "index.d.ts",
   "private": true,
   "scripts": {
-    "release": "node ./scripts/release.js"
+    "release": "node ./scripts/release.js",
+    "dev": "concurrently -k -n Server,Client -c bgBlue,bgGreen \"yarn dev:server\" \"yarn dev:client\"",
+    "dev:server": "cd packages/server && yarn dev",
+    "dev:client": "cd packages/app && yarn dev"
   },
   "workspaces": [
     "packages/**"
@@ -15,6 +18,9 @@
     "dotenv": "16.0.3",
     "7zip-min": "1.4.3",
     "axios": "0.21.1"
+  },
+  "devDependencies": {
+    "concurrently": "^7.5.0"
   },
   "version": "0.27.1"
 }


### PR DESCRIPTION
This is a developer experience improvement (Working with debugging)

This pull request don't modify any line of code

This comit allow to developer deploy a dev versión more faster

Note: Error is because i don't have `streamingServerAPIAddress` api key

> How to use: simply, go to root folder of project and run  `yarn dev`

Here is an screenshot example:

![image](https://user-images.githubusercontent.com/79398439/198168606-2bf465f7-9305-4a5e-b8ee-04e6467fce21.png)



